### PR TITLE
Change bug tracker to github and  http to https

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -38,11 +38,11 @@ List::Util   = 1.45
 keywords = static website generator plack
 
 [MetaResources]
-repository.web    = http://github.com/book/App-Wallflower
-repository.url    = http://github.com/book/App-Wallflower.git
+repository.web    = https://github.com/book/App-Wallflower
+repository.url    = https://github.com/book/App-Wallflower.git
 repository.type   = git
-bugtracker.web    = http://rt.cpan.org/NoAuth/Bugs.html?Dist=App-Wallflower
-bugtracker.mailto = bug-app-wallflower@rt.cpan.org
+bugtracker.web    = https://rt.cpan.org/NoAuth/Bugs.html?Dist=App-Wallflower
+bugtracker.mailto = https://github.com/book/App-Wallflower/issues
 
 [Meta::Contributors]
 contributor = Ferruccio Zamuner <ferz@cpan.org>


### PR DESCRIPTION
Change to use issues in GitHub as opposed to rt as recommended by [Gabor Szabo](https://perlmaven.com/how-to-add-link-to-version-control-system-of-a-cpan-distributions)